### PR TITLE
git commit -m "ATOM-PR-20260116-001-potential-fix-for-code-scanning-alert-no-5-code-injection: Your commit message"

### DIFF
--- a/.github/workflows/auto-atom-tags.yml
+++ b/.github/workflows/auto-atom-tags.yml
@@ -32,9 +32,10 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ' ') }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           # Determine type based on labels or title
-          if [ "${{ github.event_name }}" = "issues" ]; then
+          if [ "$EVENT_NAME" = "issues" ]; then
             TITLE="$ISSUE_TITLE"
             NUMBER="$ISSUE_NUMBER"
             LABELS="$ISSUE_LABELS"


### PR DESCRIPTION
Potential fix for [https://github.com/toolate28/SpiralSafe/security/code-scanning/5](https://github.com/toolate28/SpiralSafe/security/code-scanning/5)

To fix the problem, pass the untrusted issue/PR titles into the step via `env:` and then read them using normal shell environment-variable syntax (`$ISSUE_TITLE`, `$PR_TITLE`) inside the script, avoiding `${{ ... }}` in the shell body. This removes the possibility that a malicious title can alter the shell script structure.

Concretely, for the “Determine type and generate ATOM tag” step, add environment variables that capture the issue and pull request titles from the GitHub context using `${{ ... }}` in the YAML `env:` section, not in the shell body. Then, in the `run:` script, replace `TITLE="${{ github.event.issue.title }}"` with `TITLE="$ISSUE_TITLE"` and `TITLE="${{ github.event.pull_request.title }}"` with `TITLE="$PR_TITLE"`. All other logic remains unchanged. No new imports or external libraries are needed; the change is entirely within this workflow file and step.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
This pull request makes a minor update to the `auto-atom-tags.yml` GitHub Actions workflow. The change improves how the workflow accesses the issue and pull request titles by using environment variables instead of directly referencing GitHub context expressions in shell commands.

* Workflow robustness: The `Determine type and generate ATOM tag` step now sets `ISSUE_TITLE` and `PR_TITLE` as environment variables and uses them in shell commands, which helps prevent issues with variable expansion and improves script readability. [[1]](diffhunk://#diff-1f61adf404e9d9e728c589df39b07ee4913f3ec619a33c9dc4a4888f2d2cac9eR29-R35) [[2]](diffhunk://#diff-1f61adf404e9d9e728c589df39b07ee4913f3ec619a33c9dc4a4888f2d2cac9eL59-R62)
This pull request updates the GitHub Actions workflow in `.github/workflows/auto-atom-tags.yml` to improve how environment variables are handled when determining the type and generating ATOM tags. The changes make the script more readable and robust by moving GitHub event data into explicit environment variables and simplifying variable usage in the shell script.

**Workflow improvements:**

* Added explicit environment variables (`ISSUE_TITLE`, `PR_TITLE`, `ISSUE_NUMBER`, `PR_NUMBER`, `ISSUE_LABELS`, `EVENT_NAME`) for GitHub event data, replacing direct access to `${{ github.event.* }}` within the shell script for better clarity and maintainability.
* Updated shell script logic to use the newly defined environment variables instead of inline GitHub context expressions, improving consistency and reducing potential errors. [[1]](diffhunk://#diff-1f61adf404e9d9e728c589df39b07ee4913f3ec619a33c9dc4a4888f2d2cac9eR29-R41) [[2]](diffhunk://#diff-1f61adf404e9d9e728c589df39b07ee4913f3ec619a33c9dc4a4888f2d2cac9eL59-R67)
This pull request updates the `auto-atom-tags.yml` GitHub Actions workflow to improve how environment variables are managed and referenced within the script that determines the type and tag for issues and pull requests. The main focus is on simplifying and clarifying how event data is accessed and used in the workflow steps.

**Improvements to environment variable handling:**

* Explicitly sets environment variables (`ISSUE_TITLE`, `PR_TITLE`, `ISSUE_NUMBER`, `PR_NUMBER`, `ISSUE_LABELS`, `EVENT_NAME`) at the start of the step to make their usage in the script clearer and reduce repetition of `${{ github.event.* }}` expressions.

**Script simplification and consistency:**

* Refactors the shell script to use the newly defined environment variables instead of repeating GitHub Actions expressions, improving maintainability and readability. [[1]](diffhunk://#diff-1f61adf404e9d9e728c589df39b07ee4913f3ec619a33c9dc4a4888f2d2cac9eR29-R41) [[2]](diffhunk://#diff-1f61adf404e9d9e728c589df39b07ee4913f3ec619a33c9dc4a4888f2d2cac9eL59-R67)